### PR TITLE
fix: Found 2 errors in the same file, starting at: nodes/Vtiger/VtigerNode.node.ts:22

### DIFF
--- a/nodes/Vtiger/VtigerNode.node.ts
+++ b/nodes/Vtiger/VtigerNode.node.ts
@@ -4,6 +4,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
+	NodeConnectionType,
 } from 'n8n-workflow';
 import md5 from 'crypto-js/md5';
 
@@ -19,8 +20,8 @@ export class VtigerNode implements INodeType {
 		defaults: {
 			name: 'Vtiger',
 		},
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: [NodeConnectionType.Main],
+		outputs: [NodeConnectionType.Main],
 		credentials: [
 			{
 				name: 'vtigerApi',


### PR DESCRIPTION
fix error:

```
nodes/Vtiger/VtigerNode.node.ts:22:3 - error TS2322: Type '"main"[]' is not assignable to type '(NodeConnectionType | INodeInputConfiguration)[] | `={{${string}}}`'.
  Type '"main"[]' is not assignable to type '(NodeConnectionType | INodeInputConfiguration)[]'.
    Type '"main"' is not assignable to type 'NodeConnectionType | INodeInputConfiguration'.

22   inputs: ['main'],
     ~~~~~~

  node_modules/.pnpm/n8n-workflow@1.82.0/node_modules/n8n-workflow/dist/Interfaces.d.ts:1267:5
    1267     inputs: Array<NodeConnectionType | INodeInputConfiguration> | ExpressionString;
             ~~~~~~
    The expected type comes from property 'inputs' which is declared here on type 'INodeTypeDescription'

nodes/Vtiger/VtigerNode.node.ts:23:3 - error TS2322: Type '"main"[]' is not assignable to type '`={{${string}}}` | (NodeConnectionType | INodeOutputConfiguration)[]'.
  Type '"main"[]' is not assignable to type '(NodeConnectionType | INodeOutputConfiguration)[]'.
    Type '"main"' is not assignable to type 'NodeConnectionType | INodeOutputConfiguration'.

23   outputs: ['main'],
     ~~~~~~~

  node_modules/.pnpm/n8n-workflow@1.82.0/node_modules/n8n-workflow/dist/Interfaces.d.ts:1270:5
    1270     outputs: Array<NodeConnectionType | INodeOutputConfiguration> | ExpressionString;
             ~~~~~~~
    The expected type comes from property 'outputs' which is declared here on type 'INodeTypeDescription'


Found 2 errors in the same file, starting at: nodes/Vtiger/VtigerNode.node.ts:22
```

